### PR TITLE
일부 오류 수정

### DIFF
--- a/main.c
+++ b/main.c
@@ -150,7 +150,6 @@ int main() {
             }
         } */
         else if (strcmp(cmd, "pwd") == 0) {
-            load_tree_from_file(&dTree, "tree_state.txt");  // 파일에서 트리 로드
             get_pwd(&dTree);  // 트리에서 현재 경로 출력
         }
         else if (strcmp(cmd, "touch") == 0) {

--- a/pwd.c
+++ b/pwd.c
@@ -48,18 +48,14 @@ int get_pwd(DirectoryTree *dTree) {
         current = current->parent;
     }
 
-    // 루트 경로인 "/" 출력
-    if (IsEmpty(&buff)) {
-        printf("/\n");
-    } else {
-        // 스택에 저장된 경로를 출력 (루트부터 현재까지)
-        char* name;
-        while ((name = pop(&buff)) != NULL) {
-            printf("/%s", name);
-            free(name);
-        }
-        printf("\n");
+    printf("/");
+
+    char* name;
+    while ((name = pop(&buff)) != NULL) {
+	    printf("%s/", name);
+	    free(name);
     }
 
+    printf("\n");
     return 0;
 }

--- a/tree_io.c
+++ b/tree_io.c
@@ -40,7 +40,11 @@ TreeNode* load_tree_helper(FILE* file, int level) {
     node = malloc(sizeof(TreeNode));
     sscanf(line + current_level, "%c %s\n", &node->type, node->name);
     node->left = load_tree_helper(file, level + 1);
+    if (node->left != NULL)
+    	node->left->parent = node;
     node->right = load_tree_helper(file, level);
+    if (node->right != NULL)
+    	node->right->parent = node;
 
     return node;
 }
@@ -48,9 +52,9 @@ TreeNode* load_tree_helper(FILE* file, int level) {
 void load_tree_from_file(DirectoryTree* dTree, const char* filename) {
     FILE* file = fopen(filename, "r");
     if (!file) {
-        // ÆÄÀÏÀÌ Á¸ÀçÇÏÁö ¾ÊÀ¸¸é ºó Æ®¸® ÃÊ±âÈ­
-        perror("fopen"); // ¼öÁ¤µÈ ºÎºÐ: ÆÄÀÏÀÌ ¾øÀ» ¶§ÀÇ ¿À·ù ¸Þ½ÃÁö Ãâ·Â
-        TreeNode* root = malloc(sizeof(TreeNode)); //ºó Æ®¸® ÃÊ±âÈ­
+        // íŒŒì¼ì´ ì¡´ìž¬í•˜ì§€ ì•Šìœ¼ë©´ ë¹ˆ íŠ¸ë¦¬ ì´ˆê¸°í™”
+        perror("fopen"); // ìˆ˜ì •ëœ ë¶€ë¶„: íŒŒì¼ì´ ì—†ì„ ë•Œì˜ ì˜¤ë¥˜ ë©”ì‹œì§€ ì¶œë ¥
+        TreeNode* root = malloc(sizeof(TreeNode)); //ë¹ˆ íŠ¸ë¦¬ ì´ˆê¸°í™”
         strcpy(root->name, "/");
         root->type = 'd';
         root->left = NULL;

--- a/tree_state.txt
+++ b/tree_state.txt
@@ -1,0 +1,5 @@
+d /
+  d home
+    d user
+  d var
+  d tmp


### PR DESCRIPTION
pwd.c에서 printf("/");를 추가하여 최상위 디렉토리일 때도 '/' 출력
main.c에서 pwd 함수 부분에서 불필요한 load_tree_from_file() 호출 제거
tree_io.c에서 항상 NULL을 가리키던 parent 포인터에 node 값을 할당.
tree_state.txt는 명령어 테스트를 위한 기본 파일 디렉토리 파일